### PR TITLE
Added language option to the admin_session - create request

### DIFF
--- a/src/objs/nkadmin_session_obj_api.erl
+++ b/src/objs/nkadmin_session_obj_api.erl
@@ -60,7 +60,8 @@ cmd('', create, #nkapi_req{data=Data}=Req, #{srv_id:=SrvId}=State) ->
         {ok, UserId} ->
             case nkadmin_session_obj:create(SrvId, UserId) of
                 {ok, #{obj_id:=ObjId}, _Pid} ->
-                    cmd('', start, Req#nkapi_req{data=Data#{id=>ObjId}}, State);
+                    Language = nklib_util:to_binary(maps:get(language, Data, <<"en">>)),
+                    cmd('', start, Req#nkapi_req{data=Data#{id=>ObjId, language=>Language}}, State);
                 {error, Error} ->
                     {error, Error, State}
             end;

--- a/src/objs/nkadmin_session_obj_syntax.erl
+++ b/src/objs/nkadmin_session_obj_syntax.erl
@@ -42,6 +42,7 @@ api('', create, Syntax) ->
     Syntax#{
         user_id => binary,
         domain_id => binary,
+        language => {atom, [en, es]},
         events => {list, binary}
     };
 


### PR DESCRIPTION
Once an admin_session is created it is automatically started. By adding this option, the client can create and start an admin_session in a certain language in the same request.